### PR TITLE
Add DB Bootstrap Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .env
 sessions
+db/data
+db/log

--- a/db/etc/mongod.conf
+++ b/db/etc/mongod.conf
@@ -1,0 +1,11 @@
+systemLog:
+  destination: file
+  path: /var/log/mongodb/mongo.log
+  logAppend: true
+net:
+  bindIp: localhost
+  port: 27017
+storage:
+  dbPath: /data/db
+security:
+  authorization: enabled

--- a/db/initdb.d/users.sh
+++ b/db/initdb.d/users.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+mongo <<EOF
+use admin
+db.createUser({
+  user:  '$MODUS_SESSION_USER',
+  pwd: '$MODUS_SESSION_PASS',
+  roles: [{
+    role: 'readWrite',
+    db: 'modus-session'
+  }]
+})
+db.createUser({
+  user:  '$MODUS_USER',
+  pwd: '$MODUS_PASS',
+  roles: [{
+    role: 'readWrite',
+    db: 'modus'
+  }]
+})
+EOF

--- a/db/modusdb.sh
+++ b/db/modusdb.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+mkdir -p data
+mkdir -p log
+touch log/mongo.log
+chmod 666 log/mongo.log
+
+source .env
+
+docker run -d --name modus-db \
+    -e MONGO_INITDB_ROOT_USERNAME=$MONGO_ROOT_USER \
+    -e MONGO_INITDB_ROOT_PASSWORD=$MONGO_ROOT_PASS \
+    -e MODUS_SESSION_USER=$MODUS_SESSION_USER \
+    -e MODUS_SESSION_PASS=$MODUS_SESSION_PASS \
+    -e MODUS_USER=$MODUS_USER \
+    -e MODUS_PASS=$MODUS_PASS \
+    -v $MONGO_DIR/etc:/etc/mongo \
+    -v $MONGO_DIR/log:/var/log/mongodb \
+    -v $MONGO_DIR/data:/data/db \
+    -v $MONGO_DIR/initdb.d:/docker-entrypoint-initdb.d \
+    -p 27017:27017 \
+    mongo:latest \
+    --config /etc/mongo/mongod.conf


### PR DESCRIPTION
Ok so I got some stuff written that'll spin up a fresh db in a container.  It's a little hacky (here files...) but it works.  It's really just to get a dev up and running quickly with a similar DB as the rest of us.

You'll need a `.env` file in the `db` directory that basically is just a list of environment variables that get sucked into the `docker run` command via `source`

Here's an example:
```
MONGO_DIR=$(pwd)
MONGO_ROOT_USER=mongoadmin
MONGO_ROOT_PASS=password
MODUS_SESSION_USER=modussession
MODUS_SESSION_PASS=password
MODUS_USER=modus
MODUS_PASS=password
```
notice the `pwd`, so either use an absolute path or make sure to run the `modusdb.sh` from inside `./db`

Also, the `initdb.d` dir can hold whatever mongo scripts we want and will get ran at container start. See [here](https://hub.docker.com/_/mongo?tab=description#initializing-a-fresh-instance) for more.